### PR TITLE
Incremented version number.

### DIFF
--- a/spark.json
+++ b/spark.json
@@ -2,7 +2,7 @@
   "name": "FastLED",
   "author": "Daniel Garcia, Mark Kriegsman",
   "license": "MIT",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "A packaging of FastLED 3.1 for sparkcore",
   "namespace": "NSFastLED"
 }


### PR DESCRIPTION
New library changes aren't available in the Particle Build online IDE.  I assume it needs an incremented version number.